### PR TITLE
Test py3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 .#*
 dist
 build
+/.pytest_cache
+/.tox
+/venv

--- a/README.rst
+++ b/README.rst
@@ -74,3 +74,34 @@ Documentation
 
 The documentation for this package is available on `Read the Docs
 <http://vat.readthedocs.org/en/latest>`_.
+
+Contributing
+------------
+
+Here are some basic instructions for how to get the code running and testable
+on a developer's machine.
+
+To run the full suite of tests you'll need the following versions of python
+installed on your machine (we suggest using pyenv for this):
+
+- 2.7.13
+- 3.4.7
+- 3.5.4
+- 3.6.4
+
+First, fork this repo into your own Github account, then clone the repo onto
+your machine.
+
+Then create a virtual environment and install the vat package:
+
+    $ cd PATH_TO_VAT_CLONE
+    $ virtualenv venv
+    $ . venv/bin/activate
+    $ pip install -e .
+
+Now you can run the tests:
+
+    $ pip install pytest tox
+    $ tox
+
+

--- a/README.rst
+++ b/README.rst
@@ -89,19 +89,10 @@ installed on your machine (we suggest using pyenv for this):
 - 3.5.4
 - 3.6.4
 
-First, fork this repo into your own Github account, then clone the repo onto
-your machine.
+You'll also need tox installed somewhere globally.
 
-Then create a virtual environment and install the vat package:
+First, fork this repo into your own Github account, then clone the repo onto
+your machine, then run tox:
 
     $ cd PATH_TO_VAT_CLONE
-    $ virtualenv venv
-    $ . venv/bin/activate
-    $ pip install -e .
-
-Now you can run the tests:
-
-    $ pip install pytest tox
     $ tox
-
-

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import sys
 from setuptools import setup, find_packages
 from setuptools.command.test import test as TestCommand
 
+
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -14,9 +15,10 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
+
 with open('README.rst', 'rb') as f:
     long_desc = f.read().decode('utf-8')
-        
+
 setup(
     name='vat',
     version='0.3.3',
@@ -32,7 +34,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Topic :: Office/Business :: Financial',
         ],
-    package_data = {
+    package_data={
         'vat': ['gb/moss/resources/*']
         },
     tests_require=['pytest'],

--- a/tests/test_rates.py
+++ b/tests/test_rates.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals, print_function
+import vat
+import pytest
+from vat.rates import RateCache
+
+
+@pytest.mark.parametrize('member_state', vat.member_states)
+def test_rate_cache_standard_rate(member_state):
+    cache = RateCache()
+    rate = cache.standard_rate(member_state.code)
+    assert rate is not None

--- a/tests/test_vrws.py
+++ b/tests/test_vrws.py
@@ -4,6 +4,7 @@ import vat
 import pytest
 from vat import vrws
 
+
 def test_vrws():
     try:
         for ms in vat.member_states:
@@ -15,4 +16,3 @@ def test_vrws():
             pytest.skip('EU VRWS server is malfunctioning, so skipping test')
         else:
             raise
-        

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py2713,py347,py354,py364
+envlist = py27,py34,py35,py36
 [testenv]
 deps=pytest
 commands=pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py2713,py347,py354,py364
+[testenv]
+deps=pytest
+commands=pytest

--- a/vat/rates.py
+++ b/vat/rates.py
@@ -6,14 +6,15 @@ from decimal import Decimal as D
 from . import vrws
 from . import tic
 
+
 class RateCache (object):
     """Manages a cache of VAT rates fetched from europa.eu's
        VATRateWebService.  Most queries will come from the cache, which will
        only fetch new rates once per day per member state."""
-    
+
     # Historic reduced rates - VRWS currently isn't supplying reduced rate
     # information
-    
+
     # I've tried to pick, as the first entry (with no detail) the most likely
     # rate you'll want.  But you MUST check.  Also, as of 1st Sept 2015, NONE
     # of this information is available via the web service, so the detail may
@@ -49,7 +50,7 @@ class RateCache (object):
         'SE': (D('6.0'), (D('12.0'), 'Alternate')),
         'GB': (D('5.0'),),
         }
-        
+
     def __init__(self):
         self.rates = {}
 
@@ -84,7 +85,7 @@ class RateCache (object):
             if rate_date is None or rate.application_date > rate_date:
                 best_rate = rate
         return best_rate
-    
+
     def standard_rates(self, member_state, region=None):
         """Retrieve the set of standard rates for the given member state,
         optionally for the specified region.
@@ -108,7 +109,7 @@ class RateCache (object):
             return vrws.Rate(rate_info[0], the_date, rate_info[1])
         else:
             return vrws.Rate(rate_info, the_date, None)
-    
+
     def reduced_rates(self, member_state, region=None):
         """Retrieve the set of reduced rates for the given member state,
         optionally for the specified region.
@@ -133,12 +134,12 @@ class RateCache (object):
             the_date = datetime.date(2015,9,1)
             rates = [self._to_rate(r, the_date) for r in rates]
         return rates
-    
+
     def reduced_rate(self, member_state, region=None):
         """Return today’s ordinary reduced rate for the given member state
         and (optional) region."""
         return self._best_rate(self.reduced_rates(member_state, region))
-    
+
     def category_rates(self, member_state, category, region=None):
         """Retrieve the set of rates for the given member state, category
         and (optional) region.
@@ -151,14 +152,14 @@ class RateCache (object):
         if region is not None:
             rates = rates.regions[region]
         return rates.categories.get(category, [])
-    
+
     def category_rate(self, member_state, category, region=None):
         """Return today’s rate for the given member state, category and
         (optional) region."""
         return self._best_rate(self.category_rates(member_state,
                                                    category,
                                                    region))
-    
+
     def categories(self, member_state, region=None):
         """Return a list of categories for the given member state and
         (optional) region."""

--- a/vat/rates.py
+++ b/vat/rates.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import datetime
+import six
 from decimal import Decimal as D
 
 from . import vrws
@@ -55,7 +56,7 @@ class RateCache (object):
         self.rates = {}
 
     def _get_rates(self, member_state):
-        if not isinstance(member_state, basestring):
+        if not isinstance(member_state, six.string_types):
             member_state = member_state.code
         today = datetime.date.today()
         rinfo = self.rates.get(member_state, None)

--- a/vat/tic.py
+++ b/vat/tic.py
@@ -85,7 +85,7 @@ def get_rates(country, date=None):
         ('listOfTypes', 'Standard'),
         ('listOfTypes', 'Reduced'),
         ('listOfTypes', 'Category'),
-        ('dateFilter', format_date(date))])
+        ('dateFilter', format_date(date))]).encode('utf-8')
 
     f = urllib.request.urlopen(req)
 

--- a/vat/tic.py
+++ b/vat/tic.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import decimal
 from decimal import Decimal as D
 import re
-import time
 import datetime
-import six
 from six.moves import urllib
 from lxml.html import soupparser
 
@@ -14,13 +11,16 @@ from .vrws import Rate, Rates
 
 TIC_VATRATESEARCH = str('http://ec.europa.eu/taxation_customs/tic/public/vatRates/vatratesSearch.html')
 
+
 def format_date(date):
     return '{d:02d}/{m:02d}/{y:04d}'.format(y=date.year,
                                             m=date.month,
                                             d=date.day)
 
+
 class TICException(Exception):
     pass
+
 
 class TICHTTPException(TICException):
     def __init__(self, code, headers, body):
@@ -32,6 +32,7 @@ class TICHTTPException(TICException):
         return 'TICHTTPException(%r, %r, %r)' % (self.code,
                                                  self.headers,
                                                  self.body)
+
 
 msa_map = {
     'AT': 1,
@@ -64,7 +65,10 @@ msa_map = {
     'SK': 28
     }
 
+
 _percent_re = re.compile('(\d*(?:\.\d*)?)%')
+
+
 def get_rates(country, date=None):
     """Retrieve the VAT rates for the specified country.  Returns a
        Rates object on success, or in case of error raises an exception."""
@@ -72,14 +76,16 @@ def get_rates(country, date=None):
     if date is None:
         date = datetime.date.today()
 
-    req = urllib.request.Request(url=TIC_VATRATESEARCH,
-                                 headers={ 'Content-Type': 'application/x-www-form-urlencoded' })
+    req = urllib.request.Request(
+        url=TIC_VATRATESEARCH,
+        headers={'Content-Type': 'application/x-www-form-urlencoded'})
     req.method = 'POST'
-    req.data = urllib.parse.urlencode([ ('listOfMsa', msa_map[country]),
-                                        ('listOfTypes', 'Standard'),
-                                        ('listOfTypes', 'Reduced'),
-                                        ('listOfTypes', 'Category'),
-                                        ('dateFilter', format_date(date)) ])
+    req.data = urllib.parse.urlencode([
+        ('listOfMsa', msa_map[country]),
+        ('listOfTypes', 'Standard'),
+        ('listOfTypes', 'Reduced'),
+        ('listOfTypes', 'Category'),
+        ('dateFilter', format_date(date))])
 
     f = urllib.request.urlopen(req)
 
@@ -101,6 +107,6 @@ def get_rates(country, date=None):
         raise TICException("didn't understand rate %s" % std_rate)
 
     rate = Rate(D(m.group(1)), date)
-    rates = Rates({ 'Standard': rate }, {}, {})
+    rates = Rates({'Standard': rate}, {}, {})
 
     return rates


### PR DESCRIPTION
I discovered some bugs with Python3 and the RatesCache object.

This PR adds tox testing to cover Python versions 2.7, 3.4, 3.5, and 3.6.

It also adds a really simple test that reveals the bug, as well as fixing it (hopefully). When I say fixed though, I mean that the RatesCache fails in the same way for each of the Python versions. It still fails due to the VRWS service blocking the requests.