### PR TITLE
refactor: allow running in pure python environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'beautifulsoup4',
         'lxml >= 3.4.0',
         'python-dateutil >= 1.5',
-        'python-Levenshtein >= 0.11.2',
+        'Distance >= 0.1.3',
         ],
     provides=['vat']
     )

--- a/vat/addresscmp.py
+++ b/vat/addresscmp.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import distance
 import re
 import unicodedata
-import Levenshtein
 import six
 
 from . import metaphone
@@ -167,7 +167,7 @@ def _word_difference(s, t):
         return 0
     
     max_ed = max(len(s), len(t))
-    return float(Levenshtein.distance(s, t)) / max_ed
+    return float(distance.levenshtein(s, t)) / max_ed
 
 def _edit_distance(s, t):
     m = len(s)


### PR DESCRIPTION
python-Levenshtein requires C libraries whereas distance doesn't.